### PR TITLE
Add a parameter to set the executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ $info_dict = $ytdl->download($webpage_url);
 $errors = $ytdl->getErrors();
 ```
 
+If you want to set the ytdl executable path, you need to pass the value like below. This will skip the automatic scan of the executable. It is your responsibility to set this path correctly.
+```php
+$ytdl = new Ytdl($ytdl_options, null, 'usr/share/local/yt-dlp');
+```
+
 ## Examples
 - [example-0](/examples/0-version.php) with just '--version' option
 - [example-1](/examples/1-extract.php) extract example

--- a/src/Ytdl.php
+++ b/src/Ytdl.php
@@ -85,7 +85,7 @@ class Ytdl
     private Options $options;
 
 
-    public function __construct(Options $options, LoggerInterface $logger = null)
+    public function __construct(Options $options, LoggerInterface $logger = null, string $ytdl_exec = null)
     {
         if (null === $logger) {
             $logger = new NullLogger();
@@ -93,11 +93,17 @@ class Ytdl
         $this->logger = $logger;
         $this->options = $options;
 
-        $ytdl_finder = new ExecutableFinder();
-        // try first yt-dlp
-        $this->ytdl_exec = $ytdl_finder->find('yt-dlp');
-        if (null == $this->ytdl_exec) {
-            $this->ytdl_exec = $ytdl_finder->find('youtube-dl');
+        if($ytdl_exec) {
+            $this->ytdl_exec = $ytdl_exec;
+        }
+
+        if(null === $ytdl_exec) {
+            $ytdl_finder = new ExecutableFinder();
+            // try first yt-dlp
+            $this->ytdl_exec = $ytdl_finder->find('yt-dlp');
+            if (null == $this->ytdl_exec) {
+                $this->ytdl_exec = $ytdl_finder->find('youtube-dl');
+            }
         }
         $this->logger->debug('ytdl executable: ' . $this->ytdl_exec);
         $this->errors = [];


### PR DESCRIPTION
This PR is for adding an option for the user to set the executable path. This will skip the automatic scan for the executable. It is the user's responsibility to set this path correctly.

It can be used like:
```php
$ytdl = new Ytdl($ytdl_options, null, 'usr/share/local/yt-dlp');
```